### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#lru-memoize
+# lru-memoize
 
 [![NPM Version](https://img.shields.io/npm/v/lru-memoize.svg?style=flat-square)](https://www.npmjs.com/package/lru-memoize) 
 [![NPM Downloads](https://img.shields.io/npm/dm/lru-memoize.svg?style=flat-square)](https://www.npmjs.com/package/lru-memoize)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
