### PR TITLE
slice → splice while moving entry to the top

### DIFF
--- a/src/lruCache.js
+++ b/src/lruCache.js
@@ -10,7 +10,7 @@ export default function lruCache(limit, equals) {
 
       // Cached entry not at top of cache, move it to the top
       if (cacheIndex > 0) {
-        entries.slice(cacheIndex, 1)
+        entries.splice(cacheIndex, 1)
         entries.unshift(entry)
       }
 


### PR DESCRIPTION
I guess it's just a typo. We want an item to be removed at the old index and inserted at 0 on the next line. `splice` does that, `slice` does nothing.