### PR TITLE
Fix IE11 'findIndex' error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 before_install:
-  - npm install -g npm@latest
+  - npm install -g npm@5
 
 node_js:
   - "6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lru-memoize",
-  "version": "1.0.3",
+  "version": "1.0.2",
   "description": "A utility to provide lru memoization for any js function",
   "main": "./lib/index.js",
   "typings": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lru-memoize",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A utility to provide lru memoization for any js function",
   "main": "./lib/index.js",
   "typings": "./index.d.ts",

--- a/src/lruCache.js
+++ b/src/lruCache.js
@@ -1,8 +1,19 @@
+const findIndex = (arr, fn) => {
+  for (let i = 0; i < arr.length; i++) {
+    if (fn(arr[i])) {
+      return i;
+    }
+  }
+
+  return -1;
+}
+
 export default function lruCache(limit, equals) {
   const entries = []
 
   function get(key) {
-    const cacheIndex = entries.findIndex(entry => equals(key, entry.key))
+    entries 
+    const cacheIndex = findIndex(entries, entry => equals(key, entry.key))
 
     // We found a cached entry
     if (cacheIndex > -1) {


### PR DESCRIPTION
When using the `lru-memoize` package in a browser bundle, it breaks in IE11 due to this package's usage of [findIndex](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex#Browser_compatibility)

This PR fixes that by using a custom `findIndex` function that achieves the exact same functionality.

![screen shot 2019-02-11 at 5 19 37 pm](https://user-images.githubusercontent.com/7452924/52604823-536d9600-2e21-11e9-8602-0215a1fcd915.png)

/review @erikras 